### PR TITLE
chore(deps): update eslint-config and fix sass compilation

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -81,28 +81,7 @@ export default [
 
  {
   rules: {
-   "@elsikora/json/no-comments": "off", // Запрещает комменты в json
-   "@elsikora/jsx/no-autofocus": "off", // Запрещает автофокус на инпутах,
-   "@elsikora/react/1/naming-convention/filename": "off", // Некорректные правила неймингов,
-   "@elsikora/react/1/naming-convention/filename-extension": "off", // Заствялет указывать расширения файлов при импорте
    "@elsikora/react/1/no-context-provider": "off", // Форматирует Context.Provider в Context. Не собирается билд
-   "@elsikora/react/2/jsx-curly-brace-presence": "off", // Заставляет оборачивать все строки в {}
-   //    ["error", { children: "never", props: "never" }],
-   "@elsikora/react/2/require-default-props": "off",
-   "@elsikora/sonar/different-types-comparison": "off", // Запрещает сравнивать разные типы данных
-   "@elsikora/tailwindcss/enforces-negative-arbitrary-values": "off", // Запрещает указывать негативные аттрибуты
-   "@elsikora/typescript/explicit-function-return-type": "off", // Заставляет везде явно указывать тип возврата
-   "@elsikora/typescript/explicit-module-boundary-types": "off", // Заставляет везде явно указывать тип возврата
-   "@elsikora/typescript/naming-convention": "off", // Некорректные правила неймингов
-   "@elsikora/typescript/no-floating-promises": "off", // Заставляет ждать все промисы. Не собирается билд
-   "@elsikora/typescript/no-magic-numbers": "off", // Заставляет выносить все числа в отдельные константы и конфиги
-   "@elsikora/typescript/restrict-template-expressions": "off",
-   //  ["error", { allowNumber: true }], // Запрещает приводить к строке все, кроме чисел в интерполяции
-   "@elsikora/typescript/typedef": "off", // Заставляет везде явно указывать типы,
-   "@elsikora/typescript/unbound-method": "off", // Запрещает деструтуризировать функции
-
-   //    "@typescript-eslint/no-explicit-any": "error",
-   "no-console": ["warn", { allow: ["warn", "error"] }],
   },
  },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     "@commitlint/cli": "^19.8.0",
     "@commitlint/config-conventional": "^19.8.0",
     "@elsikora/commitizen-plugin-commitlint-ai": "^1.2.0",
-    "@elsikora/eslint-config": "^3.7.13",
+    "@elsikora/eslint-config": "^3.8.1",
     "@elsikora/git-branch-lint": "^1.1.0",
     "@eslint-react/eslint-plugin": "^1.42.1",
     "@rollup/plugin-alias": "^5.1.1",
@@ -2347,9 +2347,9 @@
    }
   },
   "node_modules/@elsikora/eslint-config": {
-   "version": "3.7.14",
-   "resolved": "https://registry.npmjs.org/@elsikora/eslint-config/-/eslint-config-3.7.14.tgz",
-   "integrity": "sha512-rhvPXJw3GbMisebEt3tLn9My+0Jtbs7TUX6vKUI1hDFpAWcyfYOMzUPpuxmHE3HdGXpdkEwKsVPeOAYACIgfXw==",
+   "version": "3.8.1",
+   "resolved": "https://registry.npmjs.org/@elsikora/eslint-config/-/eslint-config-3.8.1.tgz",
+   "integrity": "sha512-5omXVA4rv5WDXZd6L4hDx7SU28Z4cJeNANDYLekYvQ9xOzkrA3ziUn6/9DbU5vrjSIfmw9GACTYsgLm1jWNvTg==",
    "dev": true,
    "license": "MIT",
    "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "sb": "storybook dev -p 6006 & npm run style:dts",
   "sb-build": "storybook build",
   "style": "stylelint \"./**/*.{css,scss}\"",
-  "style:dts": "npx typed-scss-modules src/**/*.module.scss --watch --logLevel error --outputFolder dts -n none",
+  "style:dts": "npx typed-scss-modules src/**/*.module.scss --watch --logLevel error --outputFolder dts -n none --implementation sass",
   "style:fix": "stylelint \"./**/*.{css,scss}\" --fix",
   "types": "tsc --noEmit",
   "types:fix": "tsc --noEmit --skipLibCheck"
@@ -60,7 +60,7 @@
   "@commitlint/cli": "^19.8.0",
   "@commitlint/config-conventional": "^19.8.0",
   "@elsikora/commitizen-plugin-commitlint-ai": "^1.2.0",
-  "@elsikora/eslint-config": "^3.7.13",
+  "@elsikora/eslint-config": "^3.8.1",
   "@elsikora/git-branch-lint": "^1.1.0",
   "@eslint-react/eslint-plugin": "^1.42.1",
   "@rollup/plugin-alias": "^5.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -55,7 +55,7 @@ export default defineConfig([
      new Promise((resolve, reject) => {
       if (id.endsWith(".scss")) {
        try {
-        const result = sass.renderSync({
+        const result = sass.compileStringAsync({
          data: content,
          file: id,
          outFile: "styles.css",

--- a/src/shared/Accordion/hooks/useAccordionContext.ts
+++ b/src/shared/Accordion/hooks/useAccordionContext.ts
@@ -5,7 +5,7 @@ import { AccordionContext } from "../lib/accordionContext";
 export const useAccordionContext = () => {
  const accordionContext = use(AccordionContext);
 
- if (accordionContext === undefined)
+ if (accordionContext == undefined)
   throw new Error("useAccordionContext must be used within a Accordion Provider");
 
  return accordionContext;


### PR DESCRIPTION
Update @elsikora/eslint-config to version 3.8.1 and remove unnecessary rule overrides in eslint config.

Fix sass compilation method to use compileStringAsync instead of renderSync in rollup config.

Add --implementation sass flag to typed-scss-modules command.